### PR TITLE
Replace plugins_loaded with after_setup_theme

### DIFF
--- a/jwt-auth.php
+++ b/jwt-auth.php
@@ -68,4 +68,4 @@ function jwt_auth_loader() {
 	$wp_rest_keypair = new WP_REST_Key_Pair();
 	$wp_rest_keypair->init();
 }
-add_action( 'plugins_loaded', 'jwt_auth_loader' );
+add_action( 'after_setup_theme', 'jwt_auth_loader' );


### PR DESCRIPTION
This plugin doesn't work in VIP environments because it uses `plugins_loaded`, which is called before the theme is initialized and the plugin is activated.

Replacing `plugins_loaded` with `after_setup_theme` will have the plugin initialize itself after the theme has loaded.